### PR TITLE
docs: add project governance docs

### DIFF
--- a/ACCEPTABLE_USE.md
+++ b/ACCEPTABLE_USE.md
@@ -1,0 +1,47 @@
+# Acceptable Use
+
+## Summary
+
+Orca Discord Bot is self-hosted open source software released under the [MIT License](LICENSE). It is provided on an "as is" basis, without warranty. You run it at your own risk.
+
+This document is a lightweight usage policy for operators and communities that choose to deploy the bot.
+
+## Operator responsibility
+
+If you host Orca, you are responsible for:
+
+- configuring and supervising your own deployment
+- securing your bot token, server, logs, and third-party credentials
+- deciding where and how the bot is used
+- complying with applicable law and platform rules
+
+The project maintainer is not responsible for how a third party deploys or operates a self-hosted copy.
+
+## Expected use
+
+Orca is intended for lawful Discord server administration, music playback, and related community utility use.
+
+## Prohibited use
+
+Do not use Orca to:
+
+- violate Discord's Terms of Service, Community Guidelines, Developer Terms, or platform policies
+- violate the terms of Spotify, YouTube, or any other service used with the bot
+- harass, abuse, impersonate, stalk, or threaten other people
+- process or distribute unlawful, infringing, or malicious content
+- attempt unauthorized access to systems, tokens, accounts, or data
+- deploy the bot in a way that is deceptive about what it does or who operates it
+
+## Minimum age
+
+Anyone using Orca through Discord must meet Discord's minimum age requirement for their region.
+
+## Third-party terms
+
+Operators and users must comply with the terms and policies of Discord and any third-party services their deployment relies on.
+
+## No guarantee of fitness
+
+Orca is a hobby/open-source project. It is not guaranteed to be suitable for any particular purpose, moderation workflow, uptime target, or compliance regime.
+
+If you need commercial assurances, formal support, or audited controls, you should not rely on this project alone.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+This file tracks published versions of Orca Discord Bot. For the full release history, see the [GitHub Releases](https://github.com/jsun-dot/Orca-Discord-Bot/releases) page.
+
+## Unreleased
+
+- No unreleased entries yet.
+
+## [v0.1.0](https://github.com/jsun-dot/Orca-Discord-Bot/releases/tag/v0.1.0) - 2026-02-27
+
+- First public release of Orca Discord Bot.
+- Added hybrid slash/prefix music commands, queue controls, and moderation utilities.
+- Fixed now-playing controls so they stay usable longer and fail more safely when stale.
+- Expanded setup and runtime documentation for self-hosting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing
+
+Thanks for contributing to Orca Discord Bot.
+
+## Development Setup
+
+Clone the repository and create a virtual environment:
+
+```bash
+git clone https://github.com/jsun-dot/Orca-Discord-Bot.git
+cd Orca-Discord-Bot
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Install the project in editable mode:
+
+```bash
+pip install -e .
+```
+
+If you prefer, you can also install direct runtime dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Local Prerequisites
+
+- Python 3.11 or newer
+- FFmpeg on `PATH` for voice playback features
+- A Discord bot token in your local environment or `.env`
+- Spotify credentials only if you are testing Spotify playlist support
+
+## Running the Bot
+
+From the repo root, any of these entry points work:
+
+```bash
+orca-bot
+python3 -m orca_bot
+python3 main.py
+```
+
+## CI Checks
+
+Current CI is intentionally small. Before opening a PR, run the same syntax compile step used by GitHub Actions:
+
+```bash
+python3 -m compileall -q main.py orca_bot
+```
+
+If you change runtime behavior, also do the relevant manual checks locally. For example:
+
+- music playback and queue commands
+- now-playing button interactions
+- slash-command sync after startup
+- moderation commands in a test server
+
+## Pull Request Expectations
+
+- Keep changes focused and explain the user-visible impact clearly.
+- Open PRs against `main`.
+- Update docs when behavior, setup, or commands change.
+- Do not commit secrets, `.env` files, local virtual environments, or build artifacts.
+- Avoid committing generated files such as `__pycache__` or `.pyc` files.
+
+If your change affects a release-worthy behavior, include a short release note summary in the PR description so it can be folded into the changelog or GitHub release notes later.
+
+## Code Style
+
+- Match the existing project structure and naming patterns.
+- Keep comments concise and add them only where they clarify non-obvious logic.
+- Prefer small, reviewable commits and straightforward code paths over broad refactors.
+
+## Questions
+
+If you are unsure about a change, open a draft PR or issue first so scope and direction can be discussed before you spend time on implementation.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,52 @@
+# Privacy
+
+## Summary
+
+Orca Discord Bot is self-hosted software. The project maintainer does not operate a central bot service for this repository and does not receive analytics, telemetry, or usage logs from your deployment by default.
+
+If you run Orca yourself, you are the operator of that deployment and you control its configuration, logs, hosting environment, and access to any data it processes.
+
+## What the software may process
+
+Depending on how you use the bot, a self-hosted Orca deployment may process:
+
+- Discord account, server, channel, and message metadata needed to respond to commands
+- Voice and playback state needed for music features
+- Media URLs, search terms, and playlist references submitted by users
+- Local log entries written by the operator's deployment
+
+## Logging
+
+Current versions of Orca write log files locally on the machine where the bot runs. Those logs are operator-controlled.
+
+The maintainer of this repository does not automatically receive those logs.
+
+## Third-party services
+
+When enabled by the operator, Orca may send requests to third-party services that power bot functionality, such as:
+
+- Discord
+- YouTube or other media sources resolved through `yt-dlp`
+- Spotify, when Spotify playlist support is configured
+
+Those services operate under their own terms and privacy policies.
+
+## Data collection by the maintainer
+
+The maintainer does not intentionally collect personal data from self-hosted deployments through this repository or package by default.
+
+## Future AI features
+
+This project does not currently document an enabled `/ask` command or other OpenAI-backed prompt feature in the released code. If a future operator-enabled AI feature is added, this policy should be updated before release to describe what prompts are sent, to which provider, and under what configuration.
+
+## Operator responsibility
+
+If you deploy Orca for a Discord community, you are responsible for:
+
+- deciding what data is logged or retained in your environment
+- controlling access to your server, logs, and bot token
+- complying with local law and the terms of any third-party services you use
+
+## Contact
+
+If you believe this document is inaccurate for a released version of Orca, open an issue or pull request describing the gap.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Orca is a Discord bot centered on music playback, queue management, and a small 
 - Basic moderation commands
 - Simple CI on `main` via GitHub Actions
 
+## Project Docs
+
+- [CHANGELOG.md](CHANGELOG.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [SECURITY.md](SECURITY.md)
+- [PRIVACY.md](PRIVACY.md)
+- [ACCEPTABLE_USE.md](ACCEPTABLE_USE.md)
+
 ## Current Command Style
 
 All bot commands are implemented as hybrid commands, so they can be used either as:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are targeted at the latest code on `main` and, when practical, the latest release line.
+
+| Version | Supported |
+| --- | --- |
+| `main` | Yes |
+| `0.1.x` | Yes |
+| Older versions | No |
+
+## Reporting a Vulnerability
+
+Please do not open a public issue with exploit details for a suspected security vulnerability.
+
+Use one of these paths instead:
+
+1. Use GitHub's private vulnerability reporting for this repository, if it is enabled.
+2. If private reporting is not available, contact the maintainer directly through GitHub and share the details privately.
+3. If you cannot reach the maintainer privately, open a minimal public issue asking for a security contact without disclosing the exploit.
+
+Include the following when reporting:
+
+- affected version or commit
+- deployment environment
+- steps to reproduce
+- impact
+- any suggested mitigation, if known
+
+## Response expectations
+
+This is a small self-hosted open-source project, so response times are best-effort rather than guaranteed.
+
+The maintainer will try to:
+
+- confirm receipt
+- assess severity and scope
+- prepare a fix or mitigation when appropriate
+- credit reporters who want acknowledgment
+
+## Scope notes
+
+Please report vulnerabilities in the software itself, its packaging, or project-controlled infrastructure.
+
+Support requests, server misconfiguration, leaked operator tokens, or issues caused solely by third-party services are generally not security vulnerabilities in this repository, though they may still merit documentation updates.


### PR DESCRIPTION
## Summary
- add `CHANGELOG.md`, `PRIVACY.md`, `ACCEPTABLE_USE.md`, `SECURITY.md`, and `CONTRIBUTING.md`
- link the new repo docs from `README.md`
- document the current self-hosted privacy model, security reporting path, and contribution expectations

## Testing
- `git diff --check`