### PR TITLE
fix: restore queue button and inactivity notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This file tracks published versions of Orca Discord Bot. For the full release hi
 
 ## Unreleased
 
-- No unreleased entries yet.
+- Added governance and project policy docs: `CONTRIBUTING.md`, `SECURITY.md`, `PRIVACY.md`, and `ACCEPTABLE_USE.md`.
+- Fixed the now-playing queue button to render the queue again after the controls persistence changes.
+- Fixed inactivity disconnects so Orca announces why it left before stopping playback.
 
 ## [v0.1.0](https://github.com/jsun-dot/Orca-Discord-Bot/releases/tag/v0.1.0) - 2026-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file tracks published versions of Orca Discord Bot. For the full release hi
 
 ## Unreleased
 
+- No unreleased entries yet.
+
+## [v0.1.1](https://github.com/jsun-dot/Orca-Discord-Bot/releases/tag/v0.1.1) - 2026-02-28
+
 - Added governance and project policy docs: `CONTRIBUTING.md`, `SECURITY.md`, `PRIVACY.md`, and `ACCEPTABLE_USE.md`.
 - Fixed the now-playing queue button to render the queue again after the controls persistence changes.
 - Fixed inactivity disconnects so Orca announces why it left before stopping playback.

--- a/orca_bot/__init__.py
+++ b/orca_bot/__init__.py
@@ -1,3 +1,3 @@
 """Orca Discord Bot package."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/orca_bot/cogs/music.py
+++ b/orca_bot/cogs/music.py
@@ -12,7 +12,7 @@ from spotipy.oauth2 import SpotifyClientCredentials
 import logging
 
 from orca_bot.utils.voice_state import VoiceState
-from orca_bot.utils.views import QueuePages, ClearQueueConfirmation
+from orca_bot.utils.views import ClearQueueConfirmation
 from orca_bot.utils.yt_source import YTDLSource, Song, YTDLError
 
 logging.basicConfig(level=logging.INFO)
@@ -228,31 +228,7 @@ class Music(commands.Cog):
         pages = max(1, math.ceil(len(ctx.voice_state.songs) / items_per_page))
 
         requested_page = max(1, min(page, pages))  # clamp
-        embeds = []
-
-        for p in range(pages):
-            queue = ""
-            for i, song in enumerate(
-                ctx.voice_state.songs[p * items_per_page : (p + 1) * items_per_page],
-                start=p * items_per_page,
-            ):
-                queue += "`{0}.` [**{1.source.title}**]({1.source.url})\n".format(i + 1, song)
-            embed = (
-                discord.Embed(description="**{} track(s):**\n\n{}".format(len(ctx.voice_state.songs), queue))
-                .set_footer(text="Viewing page {}/{}".format(p + 1, pages))
-            )
-            embeds.append(embed)
-
-        view = QueuePages(ctx, embeds, current_page=requested_page - 1)
-
-        if ctx.voice_state.queue_message:
-            ctx.voice_state.queue_message = await ctx.voice_state.queue_message.edit(
-                embed=embeds[requested_page - 1],
-                view=view,
-            )
-        else:
-            ctx.voice_state.queue_message = await ctx.send(embed=embeds[requested_page - 1], view=view)
-        view.message = ctx.voice_state.queue_message
+        await ctx.voice_state.show_queue(requested_page)
 
     @commands.hybrid_command(name="clear", description="Clears the queue.")
     async def _clear(self, ctx: commands.Context):

--- a/orca_bot/utils/views.py
+++ b/orca_bot/utils/views.py
@@ -185,22 +185,13 @@ class NowPlayingButtons(discord.ui.View):
             await voice_state.update_now_playing_embed()
 
     async def queue_callback(self, interaction: discord.Interaction):
-        # IMPORTANT: do not reuse the original slash-command Context stored on the View.
-        # Interaction follow-up webhooks expire (~15 min), which causes "Invalid Webhook" errors.
-        # Instead, build a fresh Context from *this* button interaction.
         voice_state = self._get_active_voice_state(interaction)
         if voice_state is None:
             await self._send_inactive_message(interaction)
             return
 
         await self._defer(interaction)
-        if voice_state.is_playing:
-            new_ctx = await commands.Context.from_interaction(interaction)
-            await new_ctx.invoke(new_ctx.bot.get_command('queue'))
-        # Refresh the controls on the now playing message
-        refreshed_view = NowPlayingButtons(self.ctx)
-        refreshed_view.message = interaction.message
-        await interaction.message.edit(view=refreshed_view)
+        await voice_state.show_queue(page=1)
 
     async def skip_callback(self, interaction: discord.Interaction):
         voice_state = self._get_active_voice_state(interaction)

--- a/orca_bot/utils/voice_state.py
+++ b/orca_bot/utils/voice_state.py
@@ -66,6 +66,7 @@ class VoiceState:
         self.last_added_message = None
         self.lock = asyncio.Lock()
         self.last_activity = datetime.utcnow()
+        self._stopping = False
 
     async def add_song(self, song):
         await self.songs.put(song)
@@ -122,7 +123,10 @@ class VoiceState:
                         logging.info(f"Playing song: {self.current.source.title}")
                 except asyncio.TimeoutError:
                     logging.info("No more songs in the queue. Stopping playback.")
-                    await self.stop()
+                    await self.stop(
+                        queue_message_text="Bot disconnected from the voice channel due to inactivity.",
+                        channel_notice="Leaving voice channel due to inactivity.",
+                    )
                     return
 
             # If voice isn't connected yet, wait instead of crashing/spinning.
@@ -161,8 +165,75 @@ class VoiceState:
             logging.info("Skipping the current song...")
             self.voice.stop()
 
-    async def stop(self):
+    def _build_queue_embeds(self):
+        items_per_page = 10
+        pages = max(1, math.ceil(len(self.songs) / items_per_page))
+        embeds = []
+
+        if len(self.songs) == 0:
+            embeds.append(discord.Embed(description="**Empty queue.**"))
+            return embeds
+
+        for page in range(pages):
+            queue = ""
+            for i, song in enumerate(
+                self.songs[page * items_per_page : (page + 1) * items_per_page],
+                start=page * items_per_page,
+            ):
+                queue += "`{0}.` [**{1.source.title}**]({1.source.url})\n".format(i + 1, song)
+
+            embed = (
+                discord.Embed(description="**{} track(s):**\n\n{}".format(len(self.songs), queue))
+                .set_footer(text="Viewing page {}/{}".format(page + 1, pages))
+            )
+            embeds.append(embed)
+
+        return embeds
+
+    async def show_queue(self, page: int = 1):
+        channel = (self.queue_message.channel if self.queue_message else None) or self.text_channel or self._ctx.channel
+        if channel is None:
+            return None
+
+        embeds = self._build_queue_embeds()
+        current_page = max(0, min(page - 1, len(embeds) - 1))
+        view = QueuePages(self._ctx, embeds, current_page=current_page)
+
+        try:
+            if self.queue_message:
+                self.queue_message = await self.queue_message.edit(embed=embeds[current_page], view=view)
+            else:
+                self.queue_message = await channel.send(embed=embeds[current_page], view=view)
+        except discord.NotFound:
+            self.queue_message = await channel.send(embed=embeds[current_page], view=view)
+        except discord.errors.HTTPException as e:
+            if e.status == 401:
+                logging.error("Invalid Webhook Token. Unable to edit queue message.")
+                self.queue_message = await channel.send(embed=embeds[current_page], view=view)
+            else:
+                raise
+
+        view.message = self.queue_message
+        return self.queue_message
+
+    async def stop(
+        self,
+        *,
+        queue_message_text: str = "Bot disconnected from the voice channel. Stopping playback.",
+        channel_notice: str | None = None,
+    ):
+        if self._stopping:
+            return
+
+        self._stopping = True
         self.songs.clear()
+
+        channel = self.text_channel or self._ctx.channel
+        if channel_notice and channel and self.voice and self.voice.is_connected():
+            try:
+                await channel.send(channel_notice)
+            except Exception:
+                pass
 
         if self.voice:
             try:
@@ -194,44 +265,7 @@ class VoiceState:
     async def update_queue_message(self):
         if not self.first_song_played:
             return
-
-        ctx = self._ctx
-        items_per_page = 10
-        pages = max(1, math.ceil(len(self.songs) / items_per_page))
-        embeds = []
-
-        if len(self.songs) == 0:
-            embeds.append(discord.Embed(description='**Empty queue.**'))
-        else:
-            for page in range(pages):
-                queue = ''
-                for i, song in enumerate(
-                    self.songs[page * items_per_page : (page + 1) * items_per_page],
-                    start=page * items_per_page,
-                ):
-                    queue += '`{0}.` [**{1.source.title}**]({1.source.url})\n'.format(i + 1, song)
-
-                embed = (
-                    discord.Embed(description='**{} track(s):**\n\n{}'.format(len(self.songs), queue))
-                    .set_footer(text='Viewing page {}/{}'.format(page + 1, pages))
-                )
-                embeds.append(embed)
-
-        view = QueuePages(ctx, embeds, current_page=0)
-        channel = self.text_channel or ctx.channel
-
-        try:
-            if self.queue_message:
-                self.queue_message = await self.queue_message.edit(embed=embeds[0], view=view)
-            else:
-                self.queue_message = await channel.send(embed=embeds[0], view=view)
-            view.message = self.queue_message
-        except discord.errors.HTTPException as e:
-            if e.status == 401:
-                logging.error("Invalid Webhook Token. Unable to edit queue message.")
-                self.queue_message = None
-            else:
-                raise
+        await self.show_queue(page=1)
 
     async def ensure_queue_message_valid(self):
         if self.queue_message:
@@ -279,13 +313,10 @@ class VoiceState:
             # If there are no songs in the queue and nothing is currently playing.
             if not self.is_playing and self.songs.qsize() == 0:
                 if self.voice is not None:
-                    channel = self.text_channel or self._ctx.channel
-                    if channel:
-                        try:
-                            await channel.send("Leaving voice channel due to inactivity.")
-                        except Exception:
-                            pass
-                    await self.stop()
+                    await self.stop(
+                        queue_message_text="Bot disconnected from the voice channel due to inactivity.",
+                        channel_notice="Leaving voice channel due to inactivity.",
+                    )
                     logging.info("Inactivity timer ended: Bot stopped due to inactivity.")
                 else:
                     logging.info("Inactivity timer ended: Bot was not connected to a voice channel.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "orca-discord-bot"
-version = "0.1.0"
+version = "0.1.1"
 description = "Discord music bot with hybrid slash and prefix commands, queue controls, Spotify playlist import, and moderation tools."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- route the now-playing queue button through shared queue rendering instead of command re-invocation
- send an inactivity notice from both idle disconnect paths before stopping playback
- update the changelog unreleased section for the next release

## Testing
- `python3 -m py_compile orca_bot/utils/views.py orca_bot/utils/voice_state.py orca_bot/cogs/music.py orca_bot/bot.py main.py`
- `git diff --check`

Fixes #7
Fixes #8