### PR TITLE
chore: gitignore daily log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ ffmpeg.exe
 .DS_Store
 __pycache__/
 *.pyc
+log_*.txt
 build/
 dist/
 *.egg-info/


### PR DESCRIPTION
Adds `log_*.txt` to `.gitignore` so the daily log files created by the runtime logger cannot be accidentally staged and committed.

