### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ ffmpeg.exe
 .DS_Store
 __pycache__/
 *.pyc
+log_*.txt
 build/
 dist/
 *.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "orca-discord-bot"
-version = "0.1.1"
+version = "0.2.0"
 description = "Discord music bot with hybrid slash and prefix commands, queue controls, Spotify playlist import, and moderation tools."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps `pyproject.toml` version from `0.1.1` to `0.2.0` following the feature release in #11 (runtime profiles, interactive CLI console, structured logging).

