### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ This file tracks published versions of Orca Discord Bot. For the full release hi
 
 ## Unreleased
 
+- No unreleased entries yet.
+
+## [v0.3.0](https://github.com/jsun-dot/Orca-Discord-Bot/releases/tag/v0.3.0) - 2026-05-31
+
 ### Fixed
 - Spotify playlist playback now enqueues tracks sequentially so the first song starts playing immediately instead of waiting for an entire batch to resolve (issue #15).
 - Spotify 403 errors now surface a user-friendly embed instead of a raw exception. App owner requires an active Spotify Premium subscription.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "orca-discord-bot"
-version = "0.2.0"
+version = "0.3.0"
 description = "Discord music bot with hybrid slash and prefix commands, queue controls, Spotify playlist import, and moderation tools."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
chore: bump version to 0.3.0

- Bump version in pyproject.toml from 0.2.0 → 0.3.0
- Move CHANGELOG Unreleased → v0.3.0 (2026-05-31)

Merge after #16.