### PR TITLE
fix: create logs/ directory on startup if it does not exist

### DIFF
--- a/src/orca_bot/bot.py
+++ b/src/orca_bot/bot.py
@@ -142,6 +142,7 @@ def _configure_logger(debug: bool = False) -> logging.Logger:
 
     current_date = datetime.date.today().strftime(LOG_DATE_FORMAT)
     log_file = LOG_FILE_TEMPLATE.format(date=current_date)
+    Path(log_file).parent.mkdir(parents=True, exist_ok=True)
     file_handler = logging.FileHandler(filename=log_file, mode="a")
     file_handler.setLevel(level)
 


### PR DESCRIPTION
When installed via pip, the logs/ directory is not created automatically. FileHandler raises FileNotFoundError on first run. Use Path.mkdir with exist_ok=True to create it before opening the log file.