### PR TITLE
Feat/moderation revamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,16 @@ on:
   pull_request:
     branches:
       - main
+      - staging
   push:
     branches:
       - main
+      - staging
   workflow_dispatch:
 
 jobs:
   ci:
-    name: Syntax Check
+    name: Lint, Typecheck, and Test
     runs-on: ubuntu-latest
 
     steps:
@@ -28,6 +30,12 @@ jobs:
 
       - name: Compile Python sources
         run: python -m compileall -q main.py src/orca_bot
+
+      - name: Lint with ruff
+        run: python -m ruff check src/orca_bot tests
+
+      - name: Type check with mypy
+        run: python -m mypy src/orca_bot
 
       - name: Run tests
         run: python -m pytest

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 	@echo "Targets:"
 	@echo "  install    Install the package into the venv"
 	@echo "  dev        Install the package with dev dependencies (pytest, ruff, mypy)"
-	@echo "  test       Run the full test suite"
+	@echo "  test       Run lint, typecheck, and the full test suite"
 	@echo "  lint       Run ruff linter"
 	@echo "  format     Apply ruff formatter"
 	@echo "  typecheck  Run mypy static type checker"
@@ -25,6 +25,8 @@ dev:
 	$(PIP) install ".[dev]"
 
 test:
+	$(PYTHON) -m ruff check src/orca_bot tests
+	$(PYTHON) -m mypy src/orca_bot
 	$(PYTHON) -m pytest
 
 lint:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Orca is a Discord bot centered on music playback, queue management, and a small 
 - Spotify playlist import support
 - Queue controls with Discord button views
 - Hybrid commands: slash commands and backtick-prefixed text commands
-- Basic moderation commands
-- Simple CI on `main` via GitHub Actions
+- Moderation commands with embed responses, reason tracking, DM notifications, and role-hierarchy enforcement
+- CI on `main` and `staging` via GitHub Actions (lint, type check, tests)
 
 ## Project Docs
 
@@ -63,13 +63,27 @@ Aliases currently supported in code:
 
 ### Moderation
 
-- `/kick <user>`
+- `/kick <user> [reason]`
+- `/ban <user> [delete_days] [reason]`
+- `/unban <user_id> [reason]`
+- `/timeout <user> <minutes> [reason]`
+- `/untimeout <user> [reason]`
+- `/purge <amount> [user]`
 - `/changerole <user> <role>`
+
+All moderation commands respond with embeds, support an optional `reason`
+where applicable, DM the target user (kick/ban/timeout/untimeout), and log
+the action with the acting moderator, target, guild, and reason. Actions are
+blocked if the target outranks the caller, outranks the bot, or is the
+server owner.
 
 Permission-sensitive commands:
 
 - `pause` and `resume` require `Manage Server`
 - `kick` requires `Kick Members`
+- `ban` and `unban` require `Ban Members`
+- `timeout` and `untimeout` require `Moderate Members`
+- `purge` requires `Manage Messages`
 - `changerole` requires `Manage Roles`
 
 ## Requirements
@@ -232,6 +246,7 @@ On startup, the bot:
 |           `-- yt_source.py
 |-- tests/
 |   |-- test_bot_runtime.py
+|   |-- test_moderation.py
 |   |-- test_music_utils.py
 |   |-- test_spotify_playlist.py
 |   |-- test_starter.py
@@ -261,7 +276,7 @@ Usage: make <target>
 Targets:
   install    Install the package into the venv
   dev        Install the package with dev dependencies (pytest, ruff, mypy)
-  test       Run the full test suite
+  test       Run lint, typecheck, and the full test suite
   lint       Run ruff linter
   format     Apply ruff formatter
   typecheck  Run mypy static type checker
@@ -280,12 +295,14 @@ make dev
 
 ### CI
 
-Main branch protection is now backed by a GitHub Actions workflow and `CODEOWNERS`.
+Branch protection is backed by a GitHub Actions workflow and `CODEOWNERS`.
 
-The CI runs on every PR and push to `main`:
+The CI runs on every PR and push to `main` and `staging`:
 
 1. Compiles all Python sources (`main.py` and `src/orca_bot`)
-2. Runs the full test suite (`pytest`)
+2. Lints with ruff
+3. Type checks with mypy
+4. Runs the full test suite (`pytest`)
 
 Before opening a PR, verify locally with:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,24 @@ This file tracks published versions of Orca Discord Bot. For the full release hi
 
 ## Unreleased
 
-- No unreleased entries yet.
+### Added
+- `/ban <user> [delete_days] [reason]` — bans a member, with optional message deletion (0-7 days) and DM notification.
+- `/unban <user_id> [reason]` — unbans a user by Discord user ID.
+- `/timeout <user> <minutes> [reason]` — times out a member for 1-40320 minutes, with DM notification.
+- `/untimeout <user> [reason]` — removes an active timeout, with DM notification.
+- `/purge <amount> [user]` — bulk deletes messages with a confirmation prompt, optionally filtered to a specific user.
+
+### Changed
+- Moderation cog rewritten: all commands now use embed responses, optional `reason` parameters, DM the target user on kick/ban/timeout/untimeout, and write structured logs (actor, target, guild, reason).
+- `/kick` and `/changerole` rewritten to use the new embed and logging helpers. `/changerole` now toggles a role (adds if absent, removes if present) instead of only adding.
+- All moderation commands enforce strict role-hierarchy checks (actor must outrank target, bot must outrank target, server owner bypasses the actor check only).
+- `make test` now runs ruff and mypy in addition to the test suite. CI runs the same checks and now also triggers on the `staging` branch.
+
+### Fixed
+- `/changerole` no longer allows a member with Manage Roles to assign a role at or above their own highest role, closing a privilege-escalation path where Discord only validated the bot's role position and not the caller's.
+
+### Infrastructure
+- Renamed the `development` branch to `staging`, which is now the integration branch for feature work before merging to `main`.
 
 ## [v0.4.0](https://github.com/jsun-dot/Orca-Discord-Bot/releases/tag/v0.4.0) - 2026-06-01
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -54,20 +54,25 @@ Before opening a PR, run the full local check:
 
 ```bash
 make test
-make lint
 ```
 
-CI runs on every PR and will fail if either step fails. If you change runtime behavior, also do the relevant manual checks locally. For example:
+This runs ruff, mypy, and the test suite. CI runs on every PR and will fail if any step fails. If you change runtime behavior, also do the relevant manual checks locally. For example:
 
 - music playback and queue commands
 - now-playing button interactions
 - slash-command sync after startup
 - moderation commands in a test server
 
+## Branching
+
+- `staging` is the integration branch — feature and fix branches merge here first.
+- `main` only receives merges from `staging` when cutting a release.
+- Open PRs against `staging` unless you are submitting a hotfix for an already-released version.
+
 ## Pull Request Expectations
 
 - Keep changes focused and explain the user-visible impact clearly.
-- Open PRs against `main`.
+- Open PRs against `staging`.
 - Update docs when behavior, setup, or commands change.
 - Do not commit secrets, `.env` files, local virtual environments, or build artifacts.
 - Avoid committing generated files such as `__pycache__` or `.pyc` files.

--- a/src/orca_bot/bot.py
+++ b/src/orca_bot/bot.py
@@ -107,7 +107,7 @@ client = commands.Bot(
     intents=intents,
     help_command=None,
 )
-client.console_help_text = CONSOLE_HELP_TEXT
+client.console_help_text = CONSOLE_HELP_TEXT  # type: ignore[attr-defined]
 _persistent_views_registered = False
 
 

--- a/src/orca_bot/cogs/moderation.py
+++ b/src/orca_bot/cogs/moderation.py
@@ -1,156 +1,600 @@
-"""Moderation command cog for Orca."""
+"""Moderation commands for Orca."""
 
 import logging
+from datetime import timedelta
+from typing import Literal
 
 import discord
 from discord.ext import commands
 
-KICK_COMMAND_NAME = "kick"
-KICK_COMMAND_DESCRIPTION = (
-    "Kick a member from your server. You must have permissions to use this command."
-)
-KICK_COMMAND_OPTIONS = [
-    {
-        "name": "user",
-        "description": "User to kick from the server.",
-        "type": 6,
-        "required": True,
-    }
-]
-KICK_REASON = "Kicked by moderator."
-KICK_PERMISSION_MESSAGE = "You do not have permission to kick members."
-KICK_SUCCESS_MESSAGE = "{mention} has been kicked from the server."
-KICK_FORBIDDEN_MESSAGE = (
-    "I'm sorry, I couldn't kick that user. Make sure my role is higher "
-    "than the user you want to kick."
-)
-CHANGE_ROLE_COMMAND_NAME = "changerole"
-CHANGE_ROLE_COMMAND_DESCRIPTION = (
-    "Change the role of a specified user. You must have permissions to "
-    "use this command."
-)
-CHANGE_ROLE_COMMAND_OPTIONS = [
-    {
-        "name": "user",
-        "description": "Type a user and the role to give them.",
-        "type": 6,
-        "required": True,
-    }
-]
-CHANGE_ROLE_PERMISSION_MESSAGE = "You do not have permission to modify roles."
-BOT_ROLE_PERMISSION_MESSAGE = "I do not have permission to modify roles."
-CHANGE_ROLE_SUCCESS_MESSAGE = "{display_name}'s role has been changed to {role}."
-CHANGE_ROLE_FORBIDDEN_MESSAGE = (
-    "I'm sorry, I couldn't change that user's role due to insufficient permissions."
-)
+PURGE_AMOUNTS = Literal["10", "25", "50", "100", "All"]
+DM_FAILED_NOTICE = " (could not send DM — user may have DMs disabled)"
 
 log = logging.getLogger(__name__)
 
 
-def _format_member_tag(member: discord.Member) -> str:
-    """Return a readable member tag for moderation logging."""
-
-    return member.display_name
+def _success_embed(description: str) -> discord.Embed:
+    return discord.Embed(description=f"✅ {description}", color=discord.Color.green())
 
 
-def _log_guild_action(ctx: commands.Context, action: str) -> None:
-    """Write a moderation log entry for the current guild context."""
+def _error_embed(description: str) -> discord.Embed:
+    return discord.Embed(description=f"❌ {description}", color=discord.Color.red())
 
+
+def _dm_embed(title: str, description: str) -> discord.Embed:
+    return discord.Embed(
+        title=title, description=description, color=discord.Color.blue()
+    )
+
+
+async def _try_dm(user: discord.Member, embed: discord.Embed) -> bool:
+    """Attempt to DM a user. Returns True if successful."""
+    try:
+        await user.send(embed=embed)
+        return True
+    except (discord.Forbidden, discord.HTTPException):
+        return False
+
+
+def _hierarchy_check(
+    actor: discord.Member,
+    bot: discord.Member,
+    target: discord.Member,
+) -> str | None:
+    """Return an error message if the action is not permitted, else None.
+
+    Uses strict ordering: actor rank must be strictly greater than target rank.
+    Equal ranks cancel each other out and block the action.
+    Server owner bypasses actor rank check but bot rank is always enforced.
+    """
+    if target == actor.guild.owner:
+        return "You cannot action the server owner."
+    if actor != actor.guild.owner and target.top_role >= actor.top_role:
+        return "You cannot action someone with an equal or higher role than yours."
+    if target.top_role >= bot.top_role:
+        return "My highest role must be above the target's role to perform this action."
+    return None
+
+
+def _log_action(
+    ctx: commands.Context,
+    action: str,
+    target: str,
+    reason: str | None,
+) -> None:
     assert ctx.guild is not None
-
     log.info(
-        '%s in server "%s" (%s)',
+        '%s — %s actioned %s in "%s" (%s). Reason: %s',
         action,
+        ctx.author,
+        target,
         ctx.guild.name,
         ctx.guild.id,
+        reason or "None",
     )
+
+
+class PurgeConfirmation(discord.ui.View):
+    """Confirmation dialog for the purge command."""
+
+    def __init__(
+        self,
+        ctx: commands.Context,
+        amount: str,
+        user: discord.Member | None,
+    ) -> None:
+        super().__init__(timeout=30)
+        self.ctx = ctx
+        self.amount = amount
+        self.target_user = user
+        self.message: discord.Message | None = None
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user != self.ctx.author:
+            await interaction.response.send_message(
+                embed=_error_embed("Only the command author can use these buttons."),
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    @discord.ui.button(label="Confirm", style=discord.ButtonStyle.danger)
+    async def confirm(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        await interaction.response.defer()
+        limit = None if self.amount == "All" else int(self.amount)
+
+        def check(m: discord.Message) -> bool:
+            return self.target_user is None or m.author == self.target_user
+
+        try:
+            deleted = await interaction.channel.purge(limit=limit, check=check)
+        except discord.Forbidden:
+            if self.message:
+                try:
+                    await self.message.edit(
+                        embed=_error_embed(
+                            "I don't have permission to delete messages in this channel."
+                        ),
+                        view=None,
+                    )
+                except (discord.HTTPException, discord.Forbidden):
+                    pass
+            return
+
+        assert self.ctx.guild is not None
+        _log_action(
+            self.ctx,
+            "Purge",
+            f"{len(deleted)} messages"
+            + (f" from {self.target_user}" if self.target_user else ""),
+            None,
+        )
+
+        if self.message:
+            try:
+                await self.message.edit(
+                    embed=_success_embed(
+                        f"Deleted **{len(deleted)}** message(s)"
+                        + (
+                            f" from {self.target_user.mention}"
+                            if self.target_user
+                            else ""
+                        )
+                        + "."
+                    ),
+                    view=None,
+                )
+            except (discord.HTTPException, discord.Forbidden):
+                pass
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.secondary)
+    async def cancel(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        await interaction.response.defer()
+        if self.message:
+            try:
+                await self.message.edit(
+                    embed=discord.Embed(
+                        description="Purge cancelled.", color=discord.Color.greyple()
+                    ),
+                    view=None,
+                )
+            except (discord.HTTPException, discord.Forbidden):
+                pass
+
+    async def on_timeout(self) -> None:
+        if self.message:
+            try:
+                await self.message.edit(
+                    embed=discord.Embed(
+                        description="Purge confirmation timed out.",
+                        color=discord.Color.greyple(),
+                    ),
+                    view=None,
+                )
+            except (discord.HTTPException, discord.Forbidden):
+                pass
 
 
 class Moderation(commands.Cog):
-    """Moderation commands for kicking members and changing roles."""
+    """Moderation commands for server management."""
 
     def __init__(self, bot: commands.Bot) -> None:
-        """Store the bot instance for moderation commands."""
-
         self.bot = bot
 
-    @commands.hybrid_command(
-        name=KICK_COMMAND_NAME,
-        description=KICK_COMMAND_DESCRIPTION,
-        options=KICK_COMMAND_OPTIONS,
-    )
+    @commands.hybrid_command(name="kick", description="Kick a member from the server.")
+    @commands.has_permissions(kick_members=True)
+    @commands.guild_only()
     async def kick(
         self,
         ctx: commands.Context,
         user: discord.Member,
+        *,
+        reason: str | None = None,
     ) -> None:
-        """Kick a member from the guild if the caller has permission."""
+        """Kick a member from the guild."""
 
-        actor_tag = _format_member_tag(ctx.author)
-        target_tag = _format_member_tag(user)
+        await ctx.defer(ephemeral=True)
 
-        if not ctx.author.guild_permissions.kick_members:
-            _log_guild_action(
-                ctx,
-                f"{actor_tag} tried to kick {target_tag}, but does not have "
-                "permission to do so",
+        if user == ctx.author:
+            await ctx.send(
+                embed=_error_embed("You cannot kick yourself."), ephemeral=True
             )
-            await ctx.send(KICK_PERMISSION_MESSAGE)
+            return
+
+        if err := _hierarchy_check(ctx.author, ctx.guild.me, user):
+            await ctx.send(embed=_error_embed(err), ephemeral=True)
+            return
+
+        dm_sent = await _try_dm(
+            user,
+            _dm_embed(
+                f"You have been kicked from {ctx.guild.name}",
+                f"**Reason:** {reason or 'No reason provided.'}",
+            ),
+        )
+
+        try:
+            await user.kick(reason=reason)
+        except discord.Forbidden:
+            await ctx.send(
+                embed=_error_embed("I don't have permission to kick that user."),
+                ephemeral=True,
+            )
+            return
+
+        _log_action(ctx, "Kick", str(user), reason)
+        notice = "" if dm_sent else DM_FAILED_NOTICE
+        await ctx.send(
+            embed=_success_embed(
+                f"{user.mention} has been kicked.{notice}"
+                + (f"\n**Reason:** {reason}" if reason else "")
+            ),
+            ephemeral=True,
+        )
+
+    @commands.hybrid_command(name="ban", description="Ban a member from the server.")
+    @commands.has_permissions(ban_members=True)
+    @commands.guild_only()
+    async def ban(
+        self,
+        ctx: commands.Context,
+        user: discord.Member,
+        delete_days: int = 0,
+        *,
+        reason: str | None = None,
+    ) -> None:
+        """Ban a member from the guild."""
+
+        await ctx.defer(ephemeral=True)
+
+        if user == ctx.author:
+            await ctx.send(
+                embed=_error_embed("You cannot ban yourself."), ephemeral=True
+            )
+            return
+
+        if err := _hierarchy_check(ctx.author, ctx.guild.me, user):
+            await ctx.send(embed=_error_embed(err), ephemeral=True)
+            return
+
+        if not 0 <= delete_days <= 7:
+            await ctx.send(
+                embed=_error_embed("delete_days must be between 0 and 7."),
+                ephemeral=True,
+            )
+            return
+
+        dm_sent = await _try_dm(
+            user,
+            _dm_embed(
+                f"You have been banned from {ctx.guild.name}",
+                f"**Reason:** {reason or 'No reason provided.'}",
+            ),
+        )
+
+        try:
+            await user.ban(
+                reason=reason,
+                delete_message_days=delete_days,
+            )
+        except discord.Forbidden:
+            await ctx.send(
+                embed=_error_embed("I don't have permission to ban that user."),
+                ephemeral=True,
+            )
+            return
+
+        _log_action(ctx, "Ban", str(user), reason)
+        notice = "" if dm_sent else DM_FAILED_NOTICE
+        await ctx.send(
+            embed=_success_embed(
+                f"{user.mention} has been banned.{notice}"
+                + (f"\n**Reason:** {reason}" if reason else "")
+            ),
+            ephemeral=True,
+        )
+
+    @commands.hybrid_command(name="unban", description="Unban a user by their ID.")
+    @commands.has_permissions(ban_members=True)
+    @commands.guild_only()
+    async def unban(
+        self,
+        ctx: commands.Context,
+        user_id: str,
+        *,
+        reason: str | None = None,
+    ) -> None:
+        """Unban a previously banned user by Discord user ID."""
+
+        await ctx.defer(ephemeral=True)
+
+        try:
+            user_id_int = int(user_id)
+        except ValueError:
+            await ctx.send(
+                embed=_error_embed(
+                    "Invalid user ID. Please provide a numeric Discord user ID."
+                ),
+                ephemeral=True,
+            )
             return
 
         try:
-            await user.kick(reason=KICK_REASON)
-            _log_guild_action(ctx, f"{actor_tag} kicked {target_tag}")
-            await ctx.send(KICK_SUCCESS_MESSAGE.format(mention=user.mention))
+            ban_entry = await ctx.guild.fetch_ban(discord.Object(id=user_id_int))
+        except discord.NotFound:
+            await ctx.send(
+                embed=_error_embed(f"No ban found for user ID `{user_id}`."),
+                ephemeral=True,
+            )
+            return
+        except discord.HTTPException:
+            await ctx.send(
+                embed=_error_embed(
+                    "Failed to fetch ban information. Please try again."
+                ),
+                ephemeral=True,
+            )
+            return
+
+        try:
+            await ctx.guild.unban(ban_entry.user, reason=reason)
         except discord.Forbidden:
-            await ctx.send(KICK_FORBIDDEN_MESSAGE)
+            await ctx.send(
+                embed=_error_embed("I don't have permission to unban that user."),
+                ephemeral=True,
+            )
+            return
+
+        _log_action(ctx, "Unban", str(ban_entry.user), reason)
+        await ctx.send(
+            embed=_success_embed(
+                f"**{ban_entry.user}** has been unbanned."
+                + (f"\n**Reason:** {reason}" if reason else "")
+            ),
+            ephemeral=True,
+        )
 
     @commands.hybrid_command(
-        name=CHANGE_ROLE_COMMAND_NAME,
-        description=CHANGE_ROLE_COMMAND_DESCRIPTION,
-        options=CHANGE_ROLE_COMMAND_OPTIONS,
+        name="timeout",
+        description="Timeout a member for a specified number of minutes.",
     )
+    @commands.has_permissions(moderate_members=True)
+    @commands.guild_only()
+    async def timeout(
+        self,
+        ctx: commands.Context,
+        user: discord.Member,
+        minutes: int,
+        *,
+        reason: str | None = None,
+    ) -> None:
+        """Apply a timeout to a guild member."""
+
+        await ctx.defer(ephemeral=True)
+
+        if minutes < 1 or minutes > 40320:
+            await ctx.send(
+                embed=_error_embed(
+                    "Duration must be between 1 and 40320 minutes (28 days)."
+                ),
+                ephemeral=True,
+            )
+            return
+
+        if err := _hierarchy_check(ctx.author, ctx.guild.me, user):
+            await ctx.send(embed=_error_embed(err), ephemeral=True)
+            return
+
+        dm_sent = await _try_dm(
+            user,
+            _dm_embed(
+                f"You have been timed out in {ctx.guild.name}",
+                f"**Duration:** {minutes} minute(s)\n**Reason:** {reason or 'No reason provided.'}",
+            ),
+        )
+
+        try:
+            await user.timeout(timedelta(minutes=minutes), reason=reason)
+        except discord.Forbidden:
+            await ctx.send(
+                embed=_error_embed("I don't have permission to timeout that user."),
+                ephemeral=True,
+            )
+            return
+
+        _log_action(ctx, f"Timeout ({minutes}m)", str(user), reason)
+        notice = "" if dm_sent else DM_FAILED_NOTICE
+        await ctx.send(
+            embed=_success_embed(
+                f"{user.mention} has been timed out for **{minutes}** minute(s).{notice}"
+                + (f"\n**Reason:** {reason}" if reason else "")
+            ),
+            ephemeral=True,
+        )
+
+    @commands.hybrid_command(
+        name="untimeout", description="Remove a timeout from a member."
+    )
+    @commands.has_permissions(moderate_members=True)
+    @commands.guild_only()
+    async def untimeout(
+        self,
+        ctx: commands.Context,
+        user: discord.Member,
+        *,
+        reason: str | None = None,
+    ) -> None:
+        """Remove an active timeout from a guild member."""
+
+        await ctx.defer(ephemeral=True)
+
+        if err := _hierarchy_check(ctx.author, ctx.guild.me, user):
+            await ctx.send(embed=_error_embed(err), ephemeral=True)
+            return
+
+        if not user.is_timed_out():
+            await ctx.send(
+                embed=_error_embed(f"{user.mention} is not currently timed out."),
+                ephemeral=True,
+            )
+            return
+
+        try:
+            await user.timeout(None, reason=reason)
+        except discord.Forbidden:
+            await ctx.send(
+                embed=_error_embed("I don't have permission to remove that timeout."),
+                ephemeral=True,
+            )
+            return
+
+        await _try_dm(
+            user,
+            _dm_embed(
+                f"Your timeout in {ctx.guild.name} has been removed.",
+                f"**Reason:** {reason or 'No reason provided.'}",
+            ),
+        )
+
+        _log_action(ctx, "Untimeout", str(user), reason)
+        await ctx.send(
+            embed=_success_embed(
+                f"{user.mention}'s timeout has been removed."
+                + (f"\n**Reason:** {reason}" if reason else "")
+            ),
+            ephemeral=True,
+        )
+
+    @commands.hybrid_command(
+        name="purge", description="Bulk delete messages in this channel."
+    )
+    @commands.has_permissions(manage_messages=True)
+    @commands.guild_only()
+    async def purge(
+        self,
+        ctx: commands.Context,
+        amount: PURGE_AMOUNTS,
+        user: discord.Member | None = None,
+    ) -> None:
+        """Prompt for confirmation and bulk delete messages."""
+
+        await ctx.defer(ephemeral=True)
+
+        if amount == "All":
+            target_str = f" from {user.mention}" if user else ""
+            description = (
+                f"⚠️ This will delete **ALL** recent messages{target_str} in this channel."
+                "\n\nMessages older than 14 days cannot be bulk deleted by Discord."
+                "\n\n**This cannot be undone.**"
+            )
+        else:
+            target_str = f" from {user.mention}" if user else ""
+            description = (
+                f"Are you sure you want to delete the last **{amount}** message(s){target_str}?"
+                "\n\n**This cannot be undone.**"
+            )
+
+        view = PurgeConfirmation(ctx, amount, user)
+        view.message = await ctx.send(
+            embed=discord.Embed(
+                description=description,
+                color=discord.Color.orange(),
+            ),
+            view=view,
+            ephemeral=True,
+        )
+
+    @commands.hybrid_command(
+        name="changerole",
+        description="Add or remove a role from a member (toggles).",
+    )
+    @commands.has_permissions(manage_roles=True)
+    @commands.guild_only()
     async def changerole(
         self,
         ctx: commands.Context,
         user: discord.Member,
         role: discord.Role,
     ) -> None:
-        """Add the requested role to a member if permissions allow it."""
+        """Toggle a role on a guild member — adds if not present, removes if present."""
 
-        actor_tag = _format_member_tag(ctx.author)
-        target_tag = _format_member_tag(user)
+        await ctx.defer(ephemeral=True)
 
-        if not ctx.author.guild_permissions.manage_roles:
-            await ctx.send(CHANGE_ROLE_PERMISSION_MESSAGE)
-            _log_guild_action(
-                ctx,
-                f"{actor_tag} tried to change {target_tag}'s role to "
-                f"({role.name}), but does not have permission to do so.",
+        if role >= ctx.guild.me.top_role:
+            await ctx.send(
+                embed=_error_embed(
+                    "I cannot assign or remove a role equal to or above my own."
+                ),
+                ephemeral=True,
             )
             return
 
-        assert ctx.guild is not None
-
-        guild_member = ctx.guild.me
-        if guild_member is None or not guild_member.guild_permissions.manage_roles:
-            await ctx.send(BOT_ROLE_PERMISSION_MESSAGE)
+        if role >= ctx.author.top_role:
+            await ctx.send(
+                embed=_error_embed(
+                    "You cannot assign or remove a role equal to or above your own."
+                ),
+                ephemeral=True,
+            )
             return
 
         try:
-            await user.add_roles(role)
-            await ctx.send(
-                CHANGE_ROLE_SUCCESS_MESSAGE.format(
-                    display_name=user.display_name,
-                    role=role.name,
-                )
-            )
-            _log_guild_action(
-                ctx,
-                f"{actor_tag} changed {target_tag}'s role to ({role.name}).",
-            )
+            if role in user.roles:
+                await user.remove_roles(role, reason=f"Role toggled by {ctx.author}")
+                action = "removed from"
+            else:
+                await user.add_roles(role, reason=f"Role toggled by {ctx.author}")
+                action = "added to"
         except discord.Forbidden:
-            await ctx.send(CHANGE_ROLE_FORBIDDEN_MESSAGE)
+            await ctx.send(
+                embed=_error_embed("I don't have permission to modify that role."),
+                ephemeral=True,
+            )
+            return
+
+        _log_action(ctx, f"Role {action} {user}", str(role), None)
+        await ctx.send(
+            embed=_success_embed(
+                f"{role.mention} has been **{action}** {user.mention}."
+            ),
+            ephemeral=True,
+        )
+
+    @kick.error
+    @ban.error
+    @unban.error
+    @timeout.error
+    @untimeout.error
+    @purge.error
+    @changerole.error
+    async def moderation_error(
+        self, ctx: commands.Context, error: commands.CommandError
+    ) -> None:
+        """Handle permission and other errors for all moderation commands."""
+
+        if isinstance(error, commands.MissingPermissions):
+            await ctx.send(
+                embed=_error_embed("You don't have permission to use this command."),
+                ephemeral=True,
+            )
+        elif isinstance(error, commands.BotMissingPermissions):
+            await ctx.send(
+                embed=_error_embed("I don't have the required permissions to do that."),
+                ephemeral=True,
+            )
+        else:
+            await ctx.send(
+                embed=_error_embed(f"An error occurred: {error}"),
+                ephemeral=True,
+            )
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/tests/test_moderation.py
+++ b/tests/test_moderation.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parent.parent
+root_str = str(ROOT)
+if root_str not in sys.path:
+    sys.path.insert(0, root_str)
+
+import discord
+from orca_bot.cogs.moderation import (
+    _error_embed,
+    _hierarchy_check,
+    _success_embed,
+)
+
+
+class FakeRole:
+    """Minimal role stub that supports position-based comparison."""
+
+    def __init__(self, position: int) -> None:
+        self.position = position
+
+    def __ge__(self, other: FakeRole) -> bool:
+        return self.position >= other.position
+
+    def __gt__(self, other: FakeRole) -> bool:
+        return self.position > other.position
+
+    def __lt__(self, other: FakeRole) -> bool:
+        return self.position < other.position
+
+    def __le__(self, other: FakeRole) -> bool:
+        return self.position <= other.position
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, FakeRole):
+            return NotImplemented
+        return self.position == other.position
+
+
+def _make_member(position: int, is_owner: bool = False) -> MagicMock:
+    """Create a mock member with a given top role position."""
+    guild = MagicMock()
+    member = MagicMock()
+    member.top_role = FakeRole(position)
+    member.guild = guild
+    if is_owner:
+        guild.owner = member
+    else:
+        guild.owner = MagicMock()
+    return member
+
+
+class HierarchyCheckTests(unittest.TestCase):
+    def test_target_is_guild_owner_always_blocked(self) -> None:
+        owner = _make_member(position=10, is_owner=True)
+        actor = _make_member(position=5)
+        actor.guild = owner.guild
+        bot = _make_member(position=8)
+        bot.guild = owner.guild
+
+        result = _hierarchy_check(actor, bot, owner.guild.owner)
+        self.assertIsNotNone(result)
+        self.assertIn("owner", result.lower())
+
+    def test_actor_rank_strictly_greater_than_target_allowed(self) -> None:
+        guild = MagicMock()
+        actor = _make_member(position=5)
+        actor.guild = guild
+        target = _make_member(position=3)
+        target.guild = guild
+        bot = _make_member(position=8)
+        bot.guild = guild
+        guild.owner = MagicMock()
+
+        self.assertIsNone(_hierarchy_check(actor, bot, target))
+
+    def test_equal_ranks_cancel_out_and_block(self) -> None:
+        guild = MagicMock()
+        actor = _make_member(position=5)
+        actor.guild = guild
+        target = _make_member(position=5)
+        target.guild = guild
+        bot = _make_member(position=8)
+        bot.guild = guild
+        guild.owner = MagicMock()
+
+        result = _hierarchy_check(actor, bot, target)
+        self.assertIsNotNone(result)
+
+    def test_actor_rank_lower_than_target_blocked(self) -> None:
+        guild = MagicMock()
+        actor = _make_member(position=3)
+        actor.guild = guild
+        target = _make_member(position=5)
+        target.guild = guild
+        bot = _make_member(position=8)
+        bot.guild = guild
+        guild.owner = MagicMock()
+
+        result = _hierarchy_check(actor, bot, target)
+        self.assertIsNotNone(result)
+
+    def test_bot_rank_too_low_blocked_even_if_actor_rank_sufficient(self) -> None:
+        guild = MagicMock()
+        actor = _make_member(position=5)
+        actor.guild = guild
+        target = _make_member(position=3)
+        target.guild = guild
+        bot = _make_member(position=2)
+        bot.guild = guild
+        guild.owner = MagicMock()
+
+        result = _hierarchy_check(actor, bot, target)
+        self.assertIsNotNone(result)
+        self.assertIn("role", result.lower())
+
+    def test_server_owner_as_actor_bypasses_rank_check(self) -> None:
+        owner = _make_member(position=0, is_owner=True)
+        target = _make_member(position=0)
+        target.guild = owner.guild
+        bot = _make_member(position=5)
+        bot.guild = owner.guild
+
+        self.assertIsNone(_hierarchy_check(owner.guild.owner, bot, target))
+
+    def test_everyone_rank_equal_blocks_non_owner_actor(self) -> None:
+        guild = MagicMock()
+        actor = _make_member(position=0)
+        actor.guild = guild
+        target = _make_member(position=0)
+        target.guild = guild
+        bot = _make_member(position=5)
+        bot.guild = guild
+        guild.owner = MagicMock()
+
+        result = _hierarchy_check(actor, bot, target)
+        self.assertIsNotNone(result)
+
+    def test_bot_equal_to_target_rank_blocked(self) -> None:
+        guild = MagicMock()
+        actor = _make_member(position=5)
+        actor.guild = guild
+        target = _make_member(position=3)
+        target.guild = guild
+        bot = _make_member(position=3)
+        bot.guild = guild
+        guild.owner = MagicMock()
+
+        result = _hierarchy_check(actor, bot, target)
+        self.assertIsNotNone(result)
+
+    def test_server_owner_as_actor_still_blocked_when_bot_rank_too_low(self) -> None:
+        """Owner bypass skips the actor check only — bot rank check is always enforced."""
+        owner = _make_member(position=0, is_owner=True)
+        target = _make_member(position=5)
+        target.guild = owner.guild
+        bot = _make_member(position=4)
+        bot.guild = owner.guild
+
+        result = _hierarchy_check(owner.guild.owner, bot, target)
+        self.assertIsNotNone(result)
+
+    def test_actor_exactly_one_above_target_allowed(self) -> None:
+        """Strict ordering: rank(actor) = rank(target) + 1 should pass."""
+        guild = MagicMock()
+        actor = _make_member(position=4)
+        actor.guild = guild
+        target = _make_member(position=3)
+        target.guild = guild
+        bot = _make_member(position=10)
+        bot.guild = guild
+        guild.owner = MagicMock()
+
+        self.assertIsNone(_hierarchy_check(actor, bot, target))
+
+    def test_bot_exactly_one_above_target_allowed(self) -> None:
+        """Bot rank check: rank(bot) = rank(target) + 1 should pass."""
+        guild = MagicMock()
+        actor = _make_member(position=10)
+        actor.guild = guild
+        target = _make_member(position=3)
+        target.guild = guild
+        bot = _make_member(position=4)
+        bot.guild = guild
+        guild.owner = MagicMock()
+
+        self.assertIsNone(_hierarchy_check(actor, bot, target))
+
+    def test_all_checks_at_minimum_passing_boundary(self) -> None:
+        """All conditions satisfied by exactly 1 position — should be allowed."""
+        guild = MagicMock()
+        actor = _make_member(position=4)
+        actor.guild = guild
+        target = _make_member(position=3)
+        target.guild = guild
+        bot = _make_member(position=4)
+        bot.guild = guild
+        guild.owner = MagicMock()
+
+        self.assertIsNone(_hierarchy_check(actor, bot, target))
+
+
+class EmbedHelperTests(unittest.TestCase):
+    def test_success_embed_is_green(self) -> None:
+        embed = _success_embed("Done.")
+        self.assertEqual(embed.color, discord.Color.green())
+
+    def test_success_embed_contains_checkmark(self) -> None:
+        embed = _success_embed("Done.")
+        self.assertIn("✅", embed.description)
+
+    def test_error_embed_is_red(self) -> None:
+        embed = _error_embed("Something went wrong.")
+        self.assertEqual(embed.color, discord.Color.red())
+
+    def test_error_embed_contains_cross(self) -> None:
+        embed = _error_embed("Something went wrong.")
+        self.assertIn("❌", embed.description)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Rewrites the moderation cog from scratch, expanding it from two commands (`/kick`, `/changerole`) to a full set of seven (`/kick`, `/ban`, `/unban`, `/timeout`, `/untimeout`, `/purge`, `/changerole`), all built on shared embed, DM, hierarchy-check, and logging helpers. Also adds `staging` as the integration branch and wires ruff + mypy into `make test` and CI. Closes #21 

## Objective

Bring moderation tooling up to the same quality bar as the rest of the bot — consistent embed responses, optional reason tracking, DM notifications to affected users, and structured audit logging — while closing a privilege-escalation gap in `/changerole`.

## Problem / Issues

- The old cog only supported `/kick` and `/changerole`, using raw string constants and plain-text responses with no reason tracking, DM notifications, or structured logging.
- `/changerole` only checked that the caller had `Manage Roles` — it never checked the target role against the caller's own role position. Since the bot (not the caller) performs `add_roles`, Discord only validated the bot's hierarchy, not the caller's. Any member with `Manage Roles` could assign themselves or others a role above their own rank, including roles granting Administrator.
- `make test` only ran pytest — ruff and mypy existed as separate make targets but weren't part of the standard pre-PR check or CI.
- The `development` branch had drifted far behind `main` and wasn't usable as an integration branch.

## Results

- New commands: `/ban` (optional `delete_days` 0-7, DM), `/unban` (by user ID), `/timeout` / `/untimeout` (DM on both), `/purge` (confirmation UI, optional user filter).
- `/kick` and `/changerole` rewritten on the new helpers; `/changerole` now toggles (add/remove) and enforces strict role-hierarchy checks on the caller — fixing the privilege-escalation issue.
- All commands: embed responses, optional `reason` params, DM to target user, structured logs (actor, target, guild, reason), unified error handler.
- 16 new tests covering hierarchy-check boundary cases and embed helpers (85 total passing).
- `make test` now runs ruff + mypy + pytest; CI mirrors this and triggers on `staging`.
- `development` renamed to `staging` and reset to match `main`, now the integration branch for feature work ahead of `main`.

## Test Plan

- [x] `make test` passes (ruff, mypy, pytest — 85 tests)
- [ ] Manually verify `/kick`, `/ban`, `/unban`, `/timeout`, `/untimeout`, `/purge`, `/changerole` in a test server
- [ ] Verify DM notifications are sent on kick/ban/timeout/untimeout
- [ ] Verify hierarchy checks block actions against equal/higher-ranked members and the server owner
